### PR TITLE
feat: add watcher for events

### DIFF
--- a/.github/workflows/build-deploy.yaml
+++ b/.github/workflows/build-deploy.yaml
@@ -1,0 +1,80 @@
+name: sniffer build-and deploy
+
+on:
+  pull_request: []
+  release:
+    types: [published]
+  push:
+    branches:
+    - main
+
+jobs:
+  build-sniffer:
+    permissions:
+      packages: write
+    env:
+      container: ghcr.io/converged-computing/sniffer
+    runs-on: ubuntu-latest
+    name: build sniffer
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-go@v4
+      with:
+        go-version: ^1.21
+
+    - name: Build Containers
+      run: make build-sidecar
+
+    - name: Tag Release Image
+      if: (github.event_name == 'release')
+      run: |
+        tag=${GITHUB_REF#refs/tags/}
+        echo "Tagging and releasing ${{ env.container}}:${tag}"        
+        docker tag ${{ env.container }}:latest ${{ env.container }}:${tag}
+
+    - name: GHCR Login
+      if: (github.event_name != 'pull_request')
+      uses: docker/login-action@v2
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Deploy Container
+      if: (github.event_name != 'pull_request')
+      run: docker push ${{ env.container }} --all-tags
+
+  build-scheduler-sniffer:
+    permissions:
+      packages: write
+    env:
+      container: ghcr.io/converged-computing/scheduler-sniffer
+    runs-on: ubuntu-latest
+    name: build scheduler-sniffer
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-go@v4
+      with:
+        go-version: ^1.21
+
+    - name: Build Containers
+      run: make build
+
+    - name: Tag Release Image
+      if: (github.event_name == 'release')
+      run: |
+        tag=${GITHUB_REF#refs/tags/}
+        echo "Tagging and releasing ${{ env.container}}:${tag}"        
+        docker tag ${{ env.container }}:latest ${{ env.container }}:${tag}
+
+    - name: GHCR Login
+      if: (github.event_name != 'pull_request')
+      uses: docker/login-action@v2
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Deploy Container
+      if: (github.event_name != 'pull_request')
+      run: docker push ${{ env.container }} --all-tags

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ ARCH ?= "amd64"
 # These are passed to build the sidecar
 REGISTRY ?= ghcr.io/converged-computing
 SCHEDULER_IMAGE ?= scheduler-sniffer
-SIDECAR_IMAGE ?= sniffer-sidecar:latest
+SIDECAR_IMAGE ?= sniffer:latest
 
 .PHONY: all build clone update
 all: prepare build-sidecar build
@@ -35,7 +35,7 @@ prepare: clone clone-k8s
 	# This ensures the sig-scheduler image has the same grpc
 	cp -R sniffer/api $(UPSTREAM_K8S)/pkg/sniffer
 
-    # These basically allow us to wrap the default scheduler so we can run the command (and trace it)
+	# These basically allow us to wrap the default scheduler so we can run the command (and trace it)
 	cp scheduler/* $(UPSTREAM_K8S)/pkg/scheduler/
 	cp src/cmd/scheduler/main.go $(UPSTREAM)/cmd/scheduler/main.go
 	cp src/manifests/install/charts/as-a-second-scheduler/templates/*.yaml $(UPSTREAM)/manifests/install/charts/as-a-second-scheduler/templates/

--- a/README.md
+++ b/README.md
@@ -38,13 +38,24 @@ kubectl get events -o wide |  awk {'print $4" " $5" " $6'} | column -t | grep sn
 You can also look at the sniffer logs to see the binding events printed:
 
 ```bash
-$ kubectl exec sniffer-57f85c77d8-lgx9j -- cat /tmp/sniffer.log
-Defaulted container "sniffer" out of: sniffer, scheduler
-  DEBUG:  {"pod":"job-z2m8m","endpoint":"schedulePod","node":"kind-control-plane","event":"ScheduleSuccess","timestamp":"2024-04-21 20:54:05.171920853 +0000 UTC m=+78.753596979"}
-  DEBUG:  {"pod":"job-z2m8m","endpoint":"bindingCycle","node":"kind-control-plane","event":"BindingSuccess","timestamp":"2024-04-21 20:54:05.184822919 +0000 UTC m=+78.766499043"}
+$ kubectl exec -it sniffer-74c76ff4f8-hrqdn -c watcher -- cat /tmp/logs/sniffer.log
+```
+```console
+{"object":"Pod","name":"local-path-provisioner-7577fdbbfb-w84m2","endpoint":"podUpdate","event":"ContainersReady","timestamp":"2024-04-20 18:22:03 +0000 UTC"}
+{"object":"Pod","name":"local-path-provisioner-7577fdbbfb-w84m2","endpoint":"podUpdate","event":"PodScheduled","timestamp":"2024-04-20 18:22:00 +0000 UTC"}
 ```
 
-This is still early in development, more soon.
+You can grep for "Node" or "Pod" to filter events:
+
+```bash
+$ kubectl exec -it sniffer-74c76ff4f8-hrqdn -c watcher -- cat /tmp/logs/sniffer.log | grep Node
+```
+```console
+{"object":"Node","name":"kind-control-plane","endpoint":"nodeUpdate","reason":"KubeletReady","message":"kubelet is posting ready status","event":"Ready","timestamp":"2024-04-22 01:08:24 +0000 UTC"}
+{"object":"Node","name":"kind-control-plane","endpoint":"nodeUpdate","extra":{"capacity-cpu":"12","capacity-ephemeral-storage":"1921208544Ki","capacity-hugepages-1Gi":"0","capacity-hugepages-2Mi":"0","capacity-memory":"32512128Ki","capacity-pods":"110","allocatable-hugepages-2Mi":"0","allocatable-memory":"32512128Ki","allocatable-pods":"110","allocatable-cpu":"12","allocatable-ephemeral-storage":"1921208544Ki","allocatable-hugepages-1Gi":"0"}}
+```
+
+This is still early in development, more soon. I think likely we will need to update the output file to an actual database.
 
 ### Build Logic
 

--- a/hack/kind-build.sh
+++ b/hack/kind-build.sh
@@ -16,13 +16,13 @@ make
 
 # We load into kind so we don't need to push/pull and use up internet data ;)
 kind load docker-image ${REGISTRY}/scheduler-sniffer:latest
-kind load docker-image ${REGISTRY}/sniffer-sidecar:latest
+kind load docker-image ${REGISTRY}/sniffer:latest
 
 # And then install using the charts. The pull policy ensures we use the loaded ones
 cd ${ROOT}/upstreams/sig-scheduler-plugins/manifests/install/charts
 helm uninstall sniffer || true
 helm install \
   --set sniffer.pullPolicy=Never \
-  --set sniffer.image=${REGISTRY}/sniffer-sidecar:latest \
+  --set sniffer.image=${REGISTRY}/sniffer:latest \
   --set scheduler.image=${REGISTRY}/scheduler-sniffer:latest \
   --set scheduler.pullPolicy=Never sniffer as-a-second-scheduler/

--- a/sniffer/Makefile
+++ b/sniffer/Makefile
@@ -18,8 +18,15 @@ build:
 	docker build -f Dockerfile --build-arg ARCH="amd64" --build-arg RELEASE_VERSION="$(RELEASE_VERSION)" -t $(LOCAL_REGISTRY)/$(LOCAL_IMAGE) .
 
 .PHONY: sniffer
-sniffer: 
-	go build -ldflags '-w' -o bin/sniffer cmd/main.go
+sniffer: service watcher
+
+.PHONY: service
+service: 
+	go build -ldflags '-w' -o bin/sniffer cmd/service/service.go
+
+.PHONY: watcher
+watcher: 
+	go build -ldflags '-w' -o bin/watcher cmd/watcher/watcher.go
 
 .PHONY: protoc
 protoc: $(LOCALBIN)

--- a/sniffer/cmd/service/service.go
+++ b/sniffer/cmd/service/service.go
@@ -16,21 +16,20 @@ import (
 )
 
 const (
-	defaultPort    = ":4242"
-	defaultLogfile = "/tmp/sniffer.log"
+	defaultPort = ":4242"
 )
 
 var responsechan chan string
 
 func main() {
 	grpcPort := flag.String("port", defaultPort, "Port for grpc service")
-
+	logfile := flag.String("logfile", logger.DefaultLogFile, "Default log file to write to")
 	flag.Parse()
 
 	// Sniffer logger to file and to terminal
 	// This can eventually be a flag, but just going to set for now
 	// It shall be a very chonky file. Oh lawd he comin!
-	l := logger.NewDebugLogger(logger.LevelDebug, "/tmp/sniffer.log")
+	l := logger.NewDebugLogger(logger.LevelDebug, *logfile)
 
 	// Ensure our port starts with :
 	port := *grpcPort

--- a/sniffer/cmd/watcher/watcher.go
+++ b/sniffer/cmd/watcher/watcher.go
@@ -1,0 +1,17 @@
+package main
+
+import (
+	"flag"
+
+	"github.com/converged-computing/scheduler-sniffer/sniffer/pkg/logger"
+	"github.com/converged-computing/scheduler-sniffer/sniffer/pkg/watcher"
+)
+
+func main() {
+	logfile := flag.String("logfile", logger.DefaultLogFile, "Default log file to write to")
+	flag.Parse()
+
+	// Create a new watcher with the logfile
+	w := watcher.NewWatcher(*logfile)
+	w.Run()
+}

--- a/sniffer/pkg/logger/logger.go
+++ b/sniffer/pkg/logger/logger.go
@@ -19,6 +19,12 @@ const (
 	LevelDebug
 )
 
+// This should correspond to a shared empty dir if being
+// used alongside the scheduler-sniffer
+var (
+	DefaultLogFile = "/tmp/logs/sniffer.log"
+)
+
 type DebugLogger struct {
 	level    int
 	Filename string
@@ -49,20 +55,21 @@ func (l *DebugLogger) Stop() error {
 }
 
 // Logging functions you should use!
+// Note that prefixes are disabled because we want to parse json in each line
 func (l *DebugLogger) Info(message ...any) error {
-	return l.log(LevelInfo, "   INFO: ", message...)
+	return l.log(LevelInfo, "", message...)
 }
 func (l *DebugLogger) Error(message ...any) error {
-	return l.log(LevelError, "  ERROR: ", message...)
+	return l.log(LevelError, "", message...)
 }
 func (l *DebugLogger) Debug(message ...any) error {
-	return l.log(LevelDebug, "  DEBUG: ", message...)
+	return l.log(LevelDebug, "", message...)
 }
 func (l *DebugLogger) Verbose(message ...any) error {
-	return l.log(LevelVerbose, "VERBOSE: ", message...)
+	return l.log(LevelVerbose, "", message...)
 }
 func (l *DebugLogger) Warning(message ...any) error {
-	return l.log(LevelWarning, "WARNING: ", message...)
+	return l.log(LevelWarning, "", message...)
 }
 
 // log is the shared class function for actually printing to the log

--- a/sniffer/pkg/service/service.go
+++ b/sniffer/pkg/service/service.go
@@ -1,13 +1,13 @@
 package service
 
 import (
-	"encoding/json"
 	"fmt"
 
 	"context"
 
 	pb "github.com/converged-computing/scheduler-sniffer/sniffer/api"
 	"github.com/converged-computing/scheduler-sniffer/sniffer/pkg/logger"
+	"github.com/converged-computing/scheduler-sniffer/sniffer/pkg/types"
 )
 
 type Sniffer struct {
@@ -15,29 +15,10 @@ type Sniffer struct {
 	Logger *logger.DebugLogger
 }
 
-// A SnifferDatum holds one entry of data
-type SnifferDatum struct {
-	Pod       string `json:"pod"`
-	Endpoint  string `json:"endpoint"`
-	Node      string `json:"node"`
-	Event     string `json:"event"`
-	Timestamp string `json:"timestamp"`
-}
-
-// ToJson serializes to json
-func (d *SnifferDatum) ToJson() (string, error) {
-	out, err := json.Marshal(d)
-	if err != nil {
-		fmt.Printf("error marshalling: %s\n", err)
-		return "", err
-	}
-	return string(out), nil
-}
-
 // Send receives data from Kubernetes->scheduler module, specifically when a bind is successful
 // We are currently not using the in.Payload
 func (s *Sniffer) Send(ctx context.Context, in *pb.SendRequest) (*pb.SendResponse, error) {
-	datum := SnifferDatum{Pod: in.Pod, Endpoint: in.Endpoint, Node: in.Node, Event: in.Event, Timestamp: in.Timestamp}
+	datum := types.SnifferDatum{Name: in.Pod, Object: "Pod", Endpoint: in.Endpoint, Node: in.Node, Event: in.Event, Timestamp: in.Timestamp}
 	out, err := datum.ToJson()
 	if err == nil {
 		s.Logger.Debug("%s", out)

--- a/sniffer/pkg/types/types.go
+++ b/sniffer/pkg/types/types.go
@@ -1,0 +1,29 @@
+package types
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// A SnifferDatum holds one entry of data
+type SnifferDatum struct {
+	Object    string          `json:"object"`
+	Name      string          `json:"name"`
+	Endpoint  string          `json:"endpoint,omitempty"`
+	Reason    string          `json:"reason,omitempty"`
+	Message   string          `json:"message,omitempty"`
+	Node      string          `json:"node,omitempty"`
+	Event     string          `json:"event,omitempty"`
+	Extra     json.RawMessage `json:"extra,omitempty"`
+	Timestamp string          `json:"timestamp,omitempty"`
+}
+
+// ToJson serializes to json
+func (d *SnifferDatum) ToJson() (string, error) {
+	out, err := json.Marshal(&d)
+	if err != nil {
+		fmt.Printf("error marshalling: %s\n", err)
+		return "", err
+	}
+	return string(out), nil
+}

--- a/sniffer/pkg/watcher/events.go
+++ b/sniffer/pkg/watcher/events.go
@@ -1,0 +1,170 @@
+package watcher
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/converged-computing/scheduler-sniffer/sniffer/pkg/types"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/klog"
+)
+
+var (
+	ignoreNs = "kube-system"
+)
+
+// saveDatum is a generic function to serialize and save the data
+func (w *Watcher) saveDatum(datum types.SnifferDatum) {
+	out, err := datum.ToJson()
+	if err == nil {
+		w.log.Debug("%s", out)
+	} else {
+		fmt.Errorf("Issue with saving datum: %s", err)
+	}
+}
+
+// savePodData saves events for a pod
+func (w *Watcher) savePodData(pod *corev1.Pod, endpoint string) {
+	w.saveDatum(
+		types.SnifferDatum{
+			Name:     pod.Name,
+			Object:   "Pod",
+			Endpoint: endpoint,
+			Node:     pod.Status.NominatedNodeName,
+			Event:    string(pod.Status.Phase),
+		},
+	)
+
+	for _, condition := range pod.Status.Conditions {
+		if condition.Status != "True" {
+			continue
+		}
+
+		// Assume these are empty
+		ts := ""
+		timestamp := condition.LastProbeTime
+		if timestamp.IsZero() {
+			timestamp = condition.LastTransitionTime
+		}
+		if !timestamp.IsZero() {
+			ts = timestamp.String()
+		}
+
+		w.saveDatum(
+			types.SnifferDatum{
+				Name:      pod.Name,
+				Reason:    condition.Reason,
+				Message:   condition.Message,
+				Object:    "Pod",
+				Endpoint:  endpoint,
+				Node:      pod.Status.NominatedNodeName,
+				Event:     string(condition.Type),
+				Timestamp: ts,
+			},
+		)
+	}
+}
+
+// saveNodeData saves events for a node
+func (w *Watcher) saveNodeData(node *corev1.Node, endpoint string) {
+
+	// Generate capacity and allocatable
+	extra := "{"
+	for name, quantity := range node.Status.Capacity {
+		extra = fmt.Sprintf(`%s "capacity-%s": "%s",`, extra, name, quantity.String())
+	}
+	for name, quantity := range node.Status.Allocatable {
+		extra = fmt.Sprintf(`%s "allocatable-%s": "%s",`, extra, name, quantity.String())
+	}
+	extra = strings.TrimRight(extra, ",") + "}"
+	fmt.Println(extra)
+	w.saveDatum(
+		types.SnifferDatum{
+			Name:     node.Name,
+			Object:   "Node",
+			Endpoint: endpoint,
+			Event:    string(node.Status.Phase),
+			Extra:    json.RawMessage(extra),
+		},
+	)
+
+	for _, condition := range node.Status.Conditions {
+		if condition.Status != "True" {
+			continue
+		}
+
+		// Assume these are empty
+		ts := ""
+		timestamp := condition.LastHeartbeatTime
+		if timestamp.IsZero() {
+			timestamp = condition.LastTransitionTime
+		}
+		if !timestamp.IsZero() {
+			ts = timestamp.String()
+		}
+
+		w.saveDatum(
+			types.SnifferDatum{
+				Name:      node.Name,
+				Reason:    condition.Reason,
+				Message:   condition.Message,
+				Object:    "Node",
+				Endpoint:  endpoint,
+				Event:     string(condition.Type),
+				Timestamp: ts,
+			},
+		)
+	}
+}
+
+func (w *Watcher) podAdd(obj interface{}) {
+	pod := obj.(*corev1.Pod)
+	if pod.Namespace == ignoreNs {
+		return
+	}
+	w.savePodData(pod, "podAdd")
+	klog.Infof("POD CREATED: %s/%s", pod.Namespace, pod.Name)
+}
+
+func (w *Watcher) podUpdate(oldObj interface{}, newObj interface{}) {
+	oldPod := oldObj.(*corev1.Pod)
+	newPod := newObj.(*corev1.Pod)
+
+	if oldPod.Namespace == ignoreNs || newPod.Namespace == ignoreNs {
+		return
+	}
+	w.savePodData(newPod, "podUpdate")
+}
+
+func (w *Watcher) podDelete(obj interface{}) {
+	pod := obj.(*corev1.Pod)
+	if pod.Namespace == ignoreNs {
+		return
+	}
+	w.savePodData(pod, "podDelete")
+	klog.Infof("POD DELETED: %s/%s", pod.Namespace, pod.Name)
+}
+
+func (w *Watcher) nodeAdd(obj interface{}) {
+	node := obj.(*corev1.Node)
+	w.saveNodeData(node, "nodeAdd")
+	klog.Infof("NODE CREATED: %s", node)
+}
+
+func (w *Watcher) nodeUpdate(oldObj interface{}, newObj interface{}) {
+	oldNode := oldObj.(*corev1.Node)
+	newNode := newObj.(*corev1.Node)
+	w.saveNodeData(newNode, "nodeUpdate")
+	klog.Infof(
+		"NODE UPDATED. %s/%s %s",
+		oldNode, newNode, newNode.Status.Phase,
+	)
+}
+
+func (w *Watcher) nodeDelete(obj interface{}) {
+	node := obj.(*corev1.Node)
+	w.saveNodeData(node, "nodeDeleted")
+	klog.Infof("NODE DELETED: %s", node)
+}

--- a/sniffer/pkg/watcher/watcher.go
+++ b/sniffer/pkg/watcher/watcher.go
@@ -1,0 +1,80 @@
+package watcher
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/converged-computing/scheduler-sniffer/sniffer/pkg/logger"
+
+	"k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/cache"
+)
+
+type Watcher struct {
+	logfile string
+	log     *logger.DebugLogger
+}
+
+func NewWatcher(logfile string) *Watcher {
+	if logfile == "" {
+		logfile = logger.DefaultLogFile
+	}
+	l := logger.NewDebugLogger(logger.LevelDebug, logfile)
+
+	return &Watcher{logfile: logfile, log: l}
+}
+
+// Run the watcher, saving events to the log file
+func (w *Watcher) Run() {
+	config, err := rest.InClusterConfig()
+	if err != nil {
+		panic(err)
+	}
+
+	// create the clientset
+	clientSet, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		panic(err)
+	}
+
+	// stop signal for the informer
+	stopper := make(chan struct{})
+	defer close(stopper)
+
+	// create shared informers for pods and nodes
+	factory := informers.NewSharedInformerFactoryWithOptions(clientSet, 10*time.Second)
+	podInformer := factory.Core().V1().Pods().Informer()
+	nodeInformer := factory.Core().V1().Nodes().Informer()
+
+	defer runtime.HandleCrash()
+
+	// start informer ->
+	go factory.Start(stopper)
+
+	// start to sync and call list
+	if !cache.WaitForCacheSync(stopper, podInformer.HasSynced) {
+		runtime.HandleError(fmt.Errorf("Timed out waiting for pod caches to sync"))
+		return
+	}
+	if !cache.WaitForCacheSync(stopper, nodeInformer.HasSynced) {
+		runtime.HandleError(fmt.Errorf("Timed out waiting for node caches to sync"))
+		return
+	}
+
+	podInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    w.podAdd, // register add eventhandler
+		UpdateFunc: w.podUpdate,
+		DeleteFunc: w.podDelete,
+	})
+	nodeInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    w.nodeAdd, // register add eventhandler
+		UpdateFunc: w.nodeUpdate,
+		DeleteFunc: w.nodeDelete,
+	})
+
+	// block the main go routine from exiting
+	<-stopper
+}

--- a/src/manifests/install/charts/as-a-second-scheduler/templates/deployment.yaml
+++ b/src/manifests/install/charts/as-a-second-scheduler/templates/deployment.yaml
@@ -53,6 +53,19 @@ spec:
         - /go/src/sniffer/bin/sniffer
         - --port={{ .Values.sniffer.port }}
         name: sniffer
+        volumeMounts:
+        - name: logs-data
+          mountPath: /tmp/logs
+
+      # The watcher is running informers to see deletion events, etc.
+      - image: {{ .Values.sniffer.image }}
+        imagePullPolicy: {{ .Values.sniffer.pullPolicy }}
+        command:
+        - /go/src/sniffer/bin/watcher
+        name: watcher
+        volumeMounts:
+        - name: logs-data
+          mountPath: /tmp/logs
 
       # This is the custom scheduler that ALSO builds kubernetes -> scheduler
       - command:
@@ -87,3 +100,6 @@ spec:
       - name: scheduler-config
         configMap:
           name: scheduler-config
+      # This is a shared empty directory to write logs
+      - name: logs-data
+        emptyDir: {}

--- a/src/manifests/install/charts/as-a-second-scheduler/values.yaml
+++ b/src/manifests/install/charts/as-a-second-scheduler/values.yaml
@@ -13,6 +13,10 @@ sniffer:
   pullPolicy: Always
   port: 4242
 
+watcher:
+  image: ghcr.io/converged-computing/watcher-sidecar:latest
+  pullPolicy: Always
+
 # Here we use the default (no change)
 controller:
   name: scheduler-plugins-controller


### PR DESCRIPTION
Problem: I did not see a nice way to get (from the scheduler) a record of when a pod was done on a node. Instead, it uses the events API to go off of updated snapshots.
Solution: Do the same! We can get pretty good metadata for pods and nodes via the same events API.